### PR TITLE
Set up Raspberry Pi 5 static site and Cloudflare quick tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
 # personal_website
+
+This repository contains a very small static website meant to be served from a
+Raspberry Pi 5 using Python's built-in web server. The provided `cloudflared`
+configuration exposes the site to the internet via a temporary Cloudflare
+quick tunnel so a custom domain is not required.
+
+## Directory layout
+
+* `website/` – HTML files to be served.
+* `scripts/run_server.sh` – launches `python -m http.server` on port `8080`.
+* `systemd/website.service` – runs the server at boot.
+* `systemd/cloudflared-quick.service` – starts a Cloudflare quick tunnel for
+  external access.
+
+## Local testing
+
+```bash
+./scripts/run_server.sh &
+curl -I http://localhost:8080
+```
+
+## Raspberry Pi setup
+
+1. Install dependencies:
+
+   ```bash
+   sudo apt update && sudo apt install python3 cloudflared -y
+   ```
+
+2. Clone this repository into `/home/server/personal_website` (or adjust the
+   paths in the service files).
+
+3. Copy the unit files and enable them:
+
+   ```bash
+   sudo cp systemd/*.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now website.service cloudflared-quick.service
+   ```
+
+4. View the Cloudflare tunnel URL:
+
+   ```bash
+   journalctl -u cloudflared-quick.service -f
+   ```
+
+   Cloudflare prints a temporary `https://<random>.trycloudflare.com` address
+   that forwards traffic to your Raspberry Pi.
+
+The `server` user referenced in the unit files can be replaced with any user
+that owns the repository.
+

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(dirname "$0")/.."
-exec python -m http.server 8080 --directory ./public

--- a/scripts/run_server.sh
+++ b/scripts/run_server.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+# Serve the files in the repository's `website` directory on port 8080
+exec python -m http.server 8080 --directory ./website

--- a/systemd/cloudflared-quick.service
+++ b/systemd/cloudflared-quick.service
@@ -12,3 +12,4 @@ RestartSec=2
 
 [Install]
 WantedBy=multi-user.target
+

--- a/systemd/website.service
+++ b/systemd/website.service
@@ -5,10 +5,11 @@ After=network-online.target
 
 [Service]
 User=server
-WorkingDirectory=/home/server/personal_website/personal_website
+WorkingDirectory=/home/server/personal_website
 ExecStart=/usr/bin/env bash ./scripts/run_server.sh
 Restart=always
 RestartSec=2
 
 [Install]
 WantedBy=multi-user.target
+

--- a/website/index.html
+++ b/website/index.html
@@ -1,5 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-<meta charset="utf-8">
-<title>Test</title>
-<h1>Test</h1>
+  <head>
+    <meta charset="utf-8" />
+    <title>Test page</title>
+  </head>
+  <body>
+    <h1>It works!</h1>
+    <p>If you can read this, your Raspberry Pi 5 is serving content correctly.</p>
+  </body>
+</html>
+


### PR DESCRIPTION
## Summary
- serve `website/` via Python's http.server
- add systemd units for website and Cloudflare quick tunnel
- document Raspberry Pi setup and local testing

## Testing
- `./scripts/run_server.sh &` (then `curl -I http://localhost:8080`)
- `cloudflared --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c48b110d08832ea8d63b9369457257