### PR TITLE
Update systemd units to use home-relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ quick tunnel so a custom domain is not required.
 
 * `website/` – HTML files to be served.
 * `scripts/run_server.sh` – launches `python -m http.server` on port `8080`.
+* `scripts/run_cloudflared.sh` – opens a Cloudflare quick tunnel to the local site.
 * `systemd/website.service` – runs the server at boot.
 * `systemd/cloudflared-quick.service` – starts a Cloudflare quick tunnel for
   external access.
@@ -31,7 +32,7 @@ curl -I http://localhost:8080
 2. Clone this repository into `/home/server/personal_website` (or adjust the
    paths in the service files).
 
-3. Copy the unit files and enable them:
+3. Copy the unit files, reload systemd, and enable them:
 
    ```bash
    sudo cp systemd/*.service /etc/systemd/system/

--- a/scripts/run_cloudflared.sh
+++ b/scripts/run_cloudflared.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec /usr/bin/cloudflared --no-autoupdate tunnel --url http://127.0.0.1:8080
+

--- a/systemd/cloudflared-quick.service
+++ b/systemd/cloudflared-quick.service
@@ -5,8 +5,8 @@ After=network-online.target
 
 [Service]
 User=server
-WorkingDirectory=/home/server
-ExecStart=/usr/bin/cloudflared --no-autoupdate tunnel --url http://127.0.0.1:8080
+WorkingDirectory=%h
+ExecStart=/usr/bin/env bash %h/personal_website/scripts/run_cloudflared.sh
 Restart=always
 RestartSec=2
 

--- a/systemd/website.service
+++ b/systemd/website.service
@@ -5,8 +5,8 @@ After=network-online.target
 
 [Service]
 User=server
-WorkingDirectory=/home/server/personal_website
-ExecStart=/usr/bin/env bash ./scripts/run_server.sh
+WorkingDirectory=%h/personal_website
+ExecStart=/usr/bin/env bash %h/personal_website/scripts/run_server.sh
 Restart=always
 RestartSec=2
 


### PR DESCRIPTION
## Summary
- point systemd service working directories at the user home via %h
- invoke both ExecStart commands through repo scripts and add a cloudflared wrapper script
- document the new cloudflared script and remind installers to reload systemd after copying units

## Testing
- shellcheck scripts/run_cloudflared.sh *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c891d606f4832e9a5e124273d57697